### PR TITLE
Fixes input-group sizes

### DIFF
--- a/sass/_input-groups.scss
+++ b/sass/_input-groups.scss
@@ -27,16 +27,8 @@
 // Remix the default form control sizing classes into new ones for easier
 // manipulation.
 
-.input-group-lg > .form-control,
-.input-group-lg > .input-group-addon,
-.input-group-lg > .input-group-btn > .btn { 
-  @include input-size(lg, $input-height-large, $padding-large-vertical, $padding-large-horizontal, $font-size-large, $line-height-large, $border-radius-large);
-}
-.input-group-sm > .form-control,
-.input-group-sm > .input-group-addon,
-.input-group-sm > .input-group-btn > .btn {
-  @include input-size(sm, $input-height-small, $padding-small-vertical, $padding-small-horizontal, $font-size-small, $line-height-small, $border-radius-small);
-}
+@include input-group-size(lg, $input-height-large, $padding-large-vertical, $padding-large-horizontal, $font-size-large, $line-height-large, $border-radius-large);
+@include input-group-size(sm, $input-height-small, $padding-small-vertical, $padding-small-horizontal, $font-size-small, $line-height-small, $border-radius-small);
 
 
 // Display as table-cell

--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -906,3 +906,32 @@ $cols-lg-offset: comma-list();
     height: auto;
   }
 }
+
+// Extra mixin, not found in LESS version
+// SCSS does not allow "&" to be used like "&select" or "&textarea"
+
+@mixin input-group-size($class, $input-height, $padding-vertical, $padding-horizontal, $font-size, $line-height, $border-radius) {
+    $nested-selectors: "> .form-control, > .input-group-addon, > .input-group-btn > .btn";
+    .input-group-#{$class} {
+        #{$nested-selectors} {
+            height: $input-height;
+            padding: $padding-vertical $padding-horizontal;
+            font-size: $font-size;
+            line-height: $line-height;
+            border-radius: $border-radius;
+        }
+    }
+
+    select.input-group-#{$class} {
+        #{$nested-selectors} {
+            height: $input-height;
+            line-height: $input-height;
+        }
+    }
+
+    textarea.input-group-#{$class} {
+        #{$nested-selectors} {
+            height: auto;
+        }
+    }
+}


### PR DESCRIPTION
### The Problem

This LESS below, has no SCSS translation.

``` less
.input-size(@input-height) {
    select& {
        height: @input-height;
    }
    textarea& {
        height: auto;
    }
}
```

This is due to the placement of the ampersand (&). It's an intuitive way of using it but SCSS does not support it.

Which led to the .input-size mixin from the LESS version being incorrectly implemented in the SCSS version.

(Only showing the 1st of 6 rules to make the point concise) The outputted CSS was:

``` css
.input-group-lg > .form-control select.input-lg,
.input-group-lg > .input-group-addon select.input-lg,
.input-group-lg > .input-group-btn > .btn select.input-lg {
  height: 45px;
  line-height: 45px;
}
```

when it should have been:

``` css
select.input-group-lg > .form-control,
select.input-group-lg > .input-group-addon,
select.input-group-lg > .input-group-btn > .btn {
  height: 45px;
  line-height: 45px;
}
```
### The solution

I have remedied this by creating an extra mixin.

**Note:** The outputted CSS puts each rule on one line, rather than a new line at the comma separations. This was a consequence of refactoring the repeated selectors into the `$nested-selectors` variable (I thought it better the source be clean).

This is my first pull request so let me know if I've done else anything wrong.
